### PR TITLE
Add support for security updates.

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,6 +130,14 @@
         set, the value is automatically detected.
       </dd>
       <dt>
+        TRAVIS_DEBIAN_SECURITY_UPDATES
+      </dt>
+      <dd>
+        When <tt>true</tt>, the corresponding repository for security updates will be enabled in
+        /etc/apt/sources.list. If <tt>TRAVIS_DEBIAN_DISTRIBUTION</tt> is not
+        set, the value is automatically detected.
+      </dd>
+      <dt>
         TRAVIS_DEBIAN_EXPERIMENTAL
       </dt>
       <dd>

--- a/script.sh
+++ b/script.sh
@@ -43,6 +43,7 @@ TRAVIS_DEBIAN_INCREMENT_VERSION_NUMBER="${TRAVIS_DEBIAN_INCREMENT_VERSION_NUMBER
 #### Distribution #############################################################
 
 TRAVIS_DEBIAN_BACKPORTS="${TRAVIS_DEBIAN_BACKPORTS:-false}"
+TRAVIS_DEBIAN_SECURITY_UPDATES="${TRAVIS_DEBIAN_SECURITY_UPDATES:-false}"
 TRAVIS_DEBIAN_EXPERIMENTAL="${TRAVIS_DEBIAN_EXPERIMENTAL:-false}"
 
 if [ "${TRAVIS_DEBIAN_DISTRIBUTION:-}" = "" ]
@@ -146,6 +147,14 @@ then
 	cat >>Dockerfile <<EOF
 RUN echo "deb ${TRAVIS_DEBIAN_MIRROR} ${TRAVIS_DEBIAN_DISTRIBUTION}-backports main" >> /etc/apt/sources.list
 RUN echo "deb-src ${TRAVIS_DEBIAN_MIRROR} ${TRAVIS_DEBIAN_DISTRIBUTION}-backports main" >> /etc/apt/sources.list
+EOF
+fi
+
+if [ "${TRAVIS_DEBIAN_SECURITY_UPDATES}" = true ]
+then
+	cat >>Dockerfile <<EOF
+RUN echo "deb http://security.debian.org/ ${TRAVIS_DEBIAN_DISTRIBUTION}/updates main" >> /etc/apt/sources.list
+RUN echo "deb-src http://security.debian.org/ ${TRAVIS_DEBIAN_DISTRIBUTION}/updates main" >> /etc/apt/sources.list
 EOF
 fi
 


### PR DESCRIPTION
I just added support to enable Debian Security Updates. 

Testet with jessie: https://travis-ci.org/sedden/pkg-python-keyring/builds/112176102

BTW: The official docker image for jessie currently does not work without enabling security updates: it's not possible to install the libc6-dev package due to a version mismatch.
