### PR TITLE
also install ca-certificates

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -189,7 +189,7 @@ fi
 
 cat >>Dockerfile <<EOF
 RUN apt-get update && apt-get dist-upgrade --yes
-RUN apt-get install --yes --no-install-recommends build-essential equivs devscripts git-buildpackage
+RUN apt-get install --yes --no-install-recommends build-essential equivs devscripts git-buildpackage ca-certificates
 
 WORKDIR $(pwd)
 COPY . .


### PR DESCRIPTION
otherwise the change in 2c632ca will break pulling from https-mirrors:

```
Step 13 : RUN git fetch
 ---> Running in 1d876130af76
fatal: unable to access 'https://github.com/bzed/pkg-nagios-plugins-contrib.git/': Problem with the SSL CA cert (path? access rights?)
The command '/bin/sh -c git fetch' returned a non-zero code: 128
```
