### PR TITLE
add support for autodep8

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,7 +180,8 @@ $ git commit -m "Add .travis.yml from http://travis.debian.net."</pre>
       <dd>
         When <tt>true</tt>, run <tt>autopkgtest</tt> tests after a successful
         build. By default, tests are attempted if a
-        <tt>debian/tests/control</tt> file exists.
+        <tt>debian/tests/control</tt> file exists or <tt>debian/control</tt>
+        has the <tt>Testsuite: autopkgtest</tt> header.
       </dd>
       <dt>
         TRAVIS_DEBIAN_INCREMENT_VERSION_NUMBER

--- a/script.sh
+++ b/script.sh
@@ -136,7 +136,7 @@ esac
 
 ## Detect autopkgtest tests ###################################################
 
-if [ -e "debian/tests/control" ]
+if [ -e "debian/tests/control" ] || grep -E '^(XS-)?Testsuite: autopkgtest' debian/control
 then
 	TRAVIS_DEBIAN_AUTOPKGTEST="${TRAVIS_DEBIAN_AUTOPKGTEST:-true}"
 else
@@ -272,7 +272,7 @@ then
 	docker run --volume "$(readlink -f "${TRAVIS_DEBIAN_TARGET_DIR}"):${TRAVIS_DEBIAN_BUILD_DIR}" --interactive ${TAG} /bin/sh - <<EOF
 set -eu
 
-apt-get install --yes --no-install-recommends autopkgtest
+apt-get install --yes --no-install-recommends autopkgtest autodep8
 
 ${TRAVIS_DEBIAN_AUTOPKGTEST_RUN} ${TRAVIS_DEBIAN_BUILD_DIR}/*.changes ${TRAVIS_DEBIAN_AUTOPKGTEST_SEPARATOR} null
 EOF


### PR DESCRIPTION
those packages do not have a d/tests/control file, but announce the
support via the "Testsuite" header in d/control and generate the tests
on the fly via autodep8
