### PR TITLE
Don't rely on —show-field (was: Run tests on Ubuntu Trusty)

### DIFF
--- a/travis.yml
+++ b/travis.yml
@@ -1,4 +1,5 @@
 sudo: required
+dist: trusty
 
 services:
   - docker


### PR DESCRIPTION
Precise and Trusty are both ancient releases.
