### PR TITLE
Installing Build-Depends with debugging

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -260,7 +260,7 @@ EOF
 fi
 
 cat >>Dockerfile <<EOF
-RUN env DEBIAN_FRONTEND=noninteractive mk-build-deps --install --remove --tool 'apt-get --no-install-recommends --yes' debian/control
+RUN env DEBIAN_FRONTEND=noninteractive mk-build-deps --install --remove --tool 'apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes' debian/control
 
 RUN rm -f Dockerfile
 RUN git checkout .travis.yml || true


### PR DESCRIPTION
When build-depends are not installable, you will see which packages are
missing to fulfil them.

See also http://manpages.ubuntu.com/manpages/xenial/man1/mk-build-deps.1.html