### PR TITLE
Install lintian by default

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -226,7 +226,7 @@ fi
 
 cat >>Dockerfile <<EOF
 RUN apt-get update && apt-get dist-upgrade --yes
-RUN apt-get install --yes --no-install-recommends build-essential equivs devscripts git-buildpackage ca-certificates pristine-tar ${EXTRA_PACKAGES}
+RUN apt-get install --yes --no-install-recommends build-essential equivs devscripts git-buildpackage ca-certificates pristine-tar lintian ${EXTRA_PACKAGES}
 
 WORKDIR $(pwd)
 COPY . .


### PR DESCRIPTION
This branch is a stop-the-gap fix for #32 (although I believe it'd be worth consider this as permanent improvement, since having lintian run by default would be nice in any case).