### PR TITLE
Allow services to start in autopkgtests

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -305,6 +305,11 @@ then
 	docker run --volume "$(readlink -f "${TRAVIS_DEBIAN_TARGET_DIR}"):${TRAVIS_DEBIAN_BUILD_DIR}" --interactive ${TAG} /bin/sh - <<EOF
 set -eu
 
+cat <<EOS >/usr/sbin/policy-rc.d
+#!/bin/sh
+exit 0
+EOS
+chmod a+x /usr/sbin/policy-rc.d
 apt-get install --yes --no-install-recommends autopkgtest autodep8
 
 ${TRAVIS_DEBIAN_AUTOPKGTEST_RUN} ${TRAVIS_DEBIAN_BUILD_DIR}/*.changes ${TRAVIS_DEBIAN_AUTOPKGTEST_SEPARATOR} null


### PR DESCRIPTION
The policy-rc.d shipped in the debian:sid docker image blocks all
service starts. In order to allow autopkgtests that can e.g.  connect to
a database we have to allow for service starts.

This is used in e.g. https://travis-ci.org/agx/kopanocore-debian/builds/186870385 . The tests are not yet passing since the server start blocks for some reason but you can see that the database connections already succeeds.