### PR TITLE
Add support for derivative

### DIFF
--- a/index.html
+++ b/index.html
@@ -172,6 +172,14 @@ $ git commit -m "Add /.travis.yml to extend-diff-ignore in debian/source/options
         default, this is automatically detected from the branch name.
       </dd>
       <dt>
+        TRAVIS_DEBIAN_POCKETS
+      </dt>
+      <dd>
+        Additional pockets used for building and testing this package.
+        The pockets are set in sources.list and should be space-separated.
+        By default, this is set to "main".
+      </dd>
+      <dt>
         TRAVIS_DEBIAN_BACKPORTS
       </dt>
       <dd>

--- a/index.html
+++ b/index.html
@@ -153,6 +153,18 @@ $ git commit -m "Add /.travis.yml to extend-diff-ignore in debian/source/options
         <a href="https://wiki.debian.org/BuildProfileSpec">as described in the Build Profile spec</a>.
       </dd>
       <dt>
+        TRAVIS_DEBIAN_DERIVATIVE
+      </dt>
+      <dd>
+        Which Debian derivative to use, like "ubuntu". This will use
+        the corresponding TRAVIS_DEBIAN_DERIVATIVE:DISTRIBUTION Docker
+        container as a base.
+        You probably need to adjust TRAVIS_DEBIAN_MIRROR to target your
+        derivative archive as well.
+        Not that not all features like backports, autopkgtests or security
+        updates may be working, depending on your derivative.
+      </dd>
+      <dt>
         TRAVIS_DEBIAN_DISTRIBUTION
       </dt>
       <dd>

--- a/script.sh
+++ b/script.sh
@@ -72,6 +72,7 @@ TRAVIS_DEBIAN_INCREMENT_VERSION_NUMBER="${TRAVIS_DEBIAN_INCREMENT_VERSION_NUMBER
 #### Distribution #############################################################
 
 TRAVIS_DEBIAN_DERIVATIVE="${TRAVIS_DEBIAN_DERIVATIVE:-debian}"
+TRAVIS_DEBIAN_POCKETS="${TRAVIS_DEBIAN_POCKETS:-main}"
 TRAVIS_DEBIAN_BACKPORTS="${TRAVIS_DEBIAN_BACKPORTS:-}" # list
 TRAVIS_DEBIAN_EXPERIMENTAL="${TRAVIS_DEBIAN_EXPERIMENTAL:-false}"
 
@@ -194,6 +195,7 @@ fi
 
 Info "Using: ${TRAVIS_DEBIAN_DERIVATIVE}"
 Info "Using distribution: ${TRAVIS_DEBIAN_DISTRIBUTION}"
+Info "With pockets: ${TRAVIS_DEBIAN_POCKETS}"
 Info "Backports enabled: ${TRAVIS_DEBIAN_BACKPORTS:-<none>}"
 Info "Experimental enabled: ${TRAVIS_DEBIAN_EXPERIMENTAL}"
 Info "Security updates enabled: ${TRAVIS_DEBIAN_SECURITY_UPDATES}"
@@ -245,31 +247,31 @@ done
 
 cat >Dockerfile <<EOF
 FROM ${TRAVIS_DEBIAN_DERIVATIVE}:${TRAVIS_DEBIAN_DISTRIBUTION}
-RUN echo "deb ${TRAVIS_DEBIAN_MIRROR} ${TRAVIS_DEBIAN_DISTRIBUTION} main" > /etc/apt/sources.list
-RUN echo "deb-src ${TRAVIS_DEBIAN_MIRROR} ${TRAVIS_DEBIAN_DISTRIBUTION} main" >> /etc/apt/sources.list
+RUN echo "deb ${TRAVIS_DEBIAN_MIRROR} ${TRAVIS_DEBIAN_DISTRIBUTION} ${TRAVIS_DEBIAN_POCKETS}" > /etc/apt/sources.list
+RUN echo "deb-src ${TRAVIS_DEBIAN_MIRROR} ${TRAVIS_DEBIAN_DISTRIBUTION} ${TRAVIS_DEBIAN_POCKETS}" >> /etc/apt/sources.list
 EOF
 
 for X in $(echo "${TRAVIS_DEBIAN_BACKPORTS}")
 do
 	cat >>Dockerfile <<EOF
-RUN echo "deb ${TRAVIS_DEBIAN_MIRROR} ${X} main" >> /etc/apt/sources.list
-RUN echo "deb-src ${TRAVIS_DEBIAN_MIRROR} ${X} main" >> /etc/apt/sources.list
+RUN echo "deb ${TRAVIS_DEBIAN_MIRROR} ${X} ${TRAVIS_DEBIAN_POCKETS}" >> /etc/apt/sources.list
+RUN echo "deb-src ${TRAVIS_DEBIAN_MIRROR} ${X} ${TRAVIS_DEBIAN_POCKETS}" >> /etc/apt/sources.list
 EOF
 done
 
 if [ "${TRAVIS_DEBIAN_SECURITY_UPDATES}" = true ]
 then
 	cat >>Dockerfile <<EOF
-RUN echo "deb http://security.debian.org/ ${TRAVIS_DEBIAN_DISTRIBUTION}/updates main" >> /etc/apt/sources.list
-RUN echo "deb-src http://security.debian.org/ ${TRAVIS_DEBIAN_DISTRIBUTION}/updates main" >> /etc/apt/sources.list
+RUN echo "deb http://security.debian.org/ ${TRAVIS_DEBIAN_DISTRIBUTION}/updates ${TRAVIS_DEBIAN_POCKETS}" >> /etc/apt/sources.list
+RUN echo "deb-src http://security.debian.org/ ${TRAVIS_DEBIAN_DISTRIBUTION}/updates ${TRAVIS_DEBIAN_POCKETS}" >> /etc/apt/sources.list
 EOF
 fi
 
 if [ "${TRAVIS_DEBIAN_EXPERIMENTAL}" = true ]
 then
 	cat >>Dockerfile <<EOF
-RUN echo "deb ${TRAVIS_DEBIAN_MIRROR} experimental main" >> /etc/apt/sources.list
-RUN echo "deb-src ${TRAVIS_DEBIAN_MIRROR} experimental main" >> /etc/apt/sources.list
+RUN echo "deb ${TRAVIS_DEBIAN_MIRROR} experimental ${TRAVIS_DEBIAN_POCKETS}" >> /etc/apt/sources.list
+RUN echo "deb-src ${TRAVIS_DEBIAN_MIRROR} experimental ${TRAVIS_DEBIAN_POCKETS}" >> /etc/apt/sources.list
 EOF
 fi
 

--- a/script.sh
+++ b/script.sh
@@ -71,6 +71,7 @@ TRAVIS_DEBIAN_INCREMENT_VERSION_NUMBER="${TRAVIS_DEBIAN_INCREMENT_VERSION_NUMBER
 
 #### Distribution #############################################################
 
+TRAVIS_DEBIAN_DERIVATIVE="${TRAVIS_DEBIAN_DERIVATIVE:-debian}"
 TRAVIS_DEBIAN_BACKPORTS="${TRAVIS_DEBIAN_BACKPORTS:-}" # list
 TRAVIS_DEBIAN_EXPERIMENTAL="${TRAVIS_DEBIAN_EXPERIMENTAL:-false}"
 
@@ -191,6 +192,7 @@ fi
 
 ## Print configuration ########################################################
 
+Info "Using: ${TRAVIS_DEBIAN_DERIVATIVE}"
 Info "Using distribution: ${TRAVIS_DEBIAN_DISTRIBUTION}"
 Info "Backports enabled: ${TRAVIS_DEBIAN_BACKPORTS:-<none>}"
 Info "Experimental enabled: ${TRAVIS_DEBIAN_EXPERIMENTAL}"
@@ -242,7 +244,7 @@ done
 ## Build ######################################################################
 
 cat >Dockerfile <<EOF
-FROM debian:${TRAVIS_DEBIAN_DISTRIBUTION}
+FROM ${TRAVIS_DEBIAN_DERIVATIVE}:${TRAVIS_DEBIAN_DISTRIBUTION}
 RUN echo "deb ${TRAVIS_DEBIAN_MIRROR} ${TRAVIS_DEBIAN_DISTRIBUTION} main" > /etc/apt/sources.list
 RUN echo "deb-src ${TRAVIS_DEBIAN_MIRROR} ${TRAVIS_DEBIAN_DISTRIBUTION} main" >> /etc/apt/sources.list
 EOF


### PR DESCRIPTION
Enable Debian derivatives with Docker images and others to reuse travis.debian.net script.
Update the documentation and add 2 env variables to change container name and archive url.