### PR TITLE
Add TRAVIS_DEBIAN_DERIVATIVE option

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,6 +160,21 @@ $ git commit -m "Add /.travis.yml to extend-diff-ignore in debian/source/options
         default, this is automatically detected from the branch name.
       </dd>
       <dt>
+        TRAVIS_DEBIAN_DERIVATIVE
+      </dt>
+      <dd>
+        Which Debian derivative to use (eg. <tt>debian</tt> or <tt>ubuntu</tt>).
+        This will use the corresponding
+        <tt>TRAVIS_DEBIAN_DERIVATIVE:DISTRIBUTION</tt> Docker container
+        as a base.
+        Some derivatives are automatically derived from
+        <tt>TRAVIS_DEBIAN_DISTRIBUTION</tt>, and defaults values for
+        <tt>TRAVIS_DEBIAN_MIRROR</tt> and <tt>TRAVIS_DEBIAN_COMPONENTS</tt>
+        are then set. You can still override them as needed.
+        Note that not all features like backports, autopkgtests or security
+        updates may be work, depending on your derivative.
+      </dd>
+      <dt>
         TRAVIS_DEBIAN_COMPONENTS
       </dt>
       <dd>

--- a/index.html
+++ b/index.html
@@ -160,6 +160,15 @@ $ git commit -m "Add /.travis.yml to extend-diff-ignore in debian/source/options
         default, this is automatically detected from the branch name.
       </dd>
       <dt>
+        TRAVIS_DEBIAN_COMPONENTS
+      </dt>
+      <dd>
+        Additional archive components used for building and testing this
+        package.
+        The components are set in sources.list and should be space-separated.
+        By default, this is set to <tt>main</tt>.
+      </dd>
+      <dt>
         TRAVIS_DEBIAN_BACKPORTS
       </dt>
       <dd>

--- a/script.sh
+++ b/script.sh
@@ -71,6 +71,7 @@ TRAVIS_DEBIAN_INCREMENT_VERSION_NUMBER="${TRAVIS_DEBIAN_INCREMENT_VERSION_NUMBER
 
 #### Distribution #############################################################
 
+TRAVIS_DEBIAN_COMPONENTS="${TRAVIS_DEBIAN_COMPONENTS:-main}"
 TRAVIS_DEBIAN_BACKPORTS="${TRAVIS_DEBIAN_BACKPORTS:-}" # list
 TRAVIS_DEBIAN_EXPERIMENTAL="${TRAVIS_DEBIAN_EXPERIMENTAL:-false}"
 
@@ -192,6 +193,7 @@ fi
 ## Print configuration ########################################################
 
 Info "Using distribution: ${TRAVIS_DEBIAN_DISTRIBUTION}"
+Info "With components: ${TRAVIS_DEBIAN_COMPONENTS}"
 Info "Backports enabled: ${TRAVIS_DEBIAN_BACKPORTS:-<none>}"
 Info "Experimental enabled: ${TRAVIS_DEBIAN_EXPERIMENTAL}"
 Info "Security updates enabled: ${TRAVIS_DEBIAN_SECURITY_UPDATES}"
@@ -243,31 +245,31 @@ done
 
 cat >Dockerfile <<EOF
 FROM debian:${TRAVIS_DEBIAN_DISTRIBUTION}
-RUN echo "deb ${TRAVIS_DEBIAN_MIRROR} ${TRAVIS_DEBIAN_DISTRIBUTION} main" > /etc/apt/sources.list
-RUN echo "deb-src ${TRAVIS_DEBIAN_MIRROR} ${TRAVIS_DEBIAN_DISTRIBUTION} main" >> /etc/apt/sources.list
+RUN echo "deb ${TRAVIS_DEBIAN_MIRROR} ${TRAVIS_DEBIAN_DISTRIBUTION} ${TRAVIS_DEBIAN_COMPONENTS}" > /etc/apt/sources.list
+RUN echo "deb-src ${TRAVIS_DEBIAN_MIRROR} ${TRAVIS_DEBIAN_DISTRIBUTION} ${TRAVIS_DEBIAN_COMPONENTS}" >> /etc/apt/sources.list
 EOF
 
 for X in $(echo "${TRAVIS_DEBIAN_BACKPORTS}")
 do
 	cat >>Dockerfile <<EOF
-RUN echo "deb ${TRAVIS_DEBIAN_MIRROR} ${X} main" >> /etc/apt/sources.list
-RUN echo "deb-src ${TRAVIS_DEBIAN_MIRROR} ${X} main" >> /etc/apt/sources.list
+RUN echo "deb ${TRAVIS_DEBIAN_MIRROR} ${X} ${TRAVIS_DEBIAN_COMPONENTS}" >> /etc/apt/sources.list
+RUN echo "deb-src ${TRAVIS_DEBIAN_MIRROR} ${X} ${TRAVIS_DEBIAN_COMPONENTS}" >> /etc/apt/sources.list
 EOF
 done
 
 if [ "${TRAVIS_DEBIAN_SECURITY_UPDATES}" = true ]
 then
 	cat >>Dockerfile <<EOF
-RUN echo "deb http://security.debian.org/ ${TRAVIS_DEBIAN_DISTRIBUTION}/updates main" >> /etc/apt/sources.list
-RUN echo "deb-src http://security.debian.org/ ${TRAVIS_DEBIAN_DISTRIBUTION}/updates main" >> /etc/apt/sources.list
+RUN echo "deb http://security.debian.org/ ${TRAVIS_DEBIAN_DISTRIBUTION}/updates ${TRAVIS_DEBIAN_COMPONENTS}" >> /etc/apt/sources.list
+RUN echo "deb-src http://security.debian.org/ ${TRAVIS_DEBIAN_DISTRIBUTION}/updates ${TRAVIS_DEBIAN_COMPONENTS}" >> /etc/apt/sources.list
 EOF
 fi
 
 if [ "${TRAVIS_DEBIAN_EXPERIMENTAL}" = true ]
 then
 	cat >>Dockerfile <<EOF
-RUN echo "deb ${TRAVIS_DEBIAN_MIRROR} experimental main" >> /etc/apt/sources.list
-RUN echo "deb-src ${TRAVIS_DEBIAN_MIRROR} experimental main" >> /etc/apt/sources.list
+RUN echo "deb ${TRAVIS_DEBIAN_MIRROR} experimental ${TRAVIS_DEBIAN_COMPONENTS}" >> /etc/apt/sources.list
+RUN echo "deb-src ${TRAVIS_DEBIAN_MIRROR} experimental ${TRAVIS_DEBIAN_COMPONENTS}" >> /etc/apt/sources.list
 EOF
 fi
 


### PR DESCRIPTION
Which Debian derivative to use, like "ubuntu". This will use the corresponding TRAVIS_DEBIAN_DERIVATIVE:DISTRIBUTION Docker container as a base.
Some derivatives are automatically derived from TRAVIS_DEBIAN_DISTRIBUTION, and defaults values for TRAVIS_DEBIAN_MIRROR and TRAVIS_DEBIAN_COMPONENTS are then set. You can still override them as needed.
Note that not all features like backports, autopkgtests or security updates may be working, depending on your derivative.